### PR TITLE
Fix empty download bug if URL contains page number

### DIFF
--- a/framework.py
+++ b/framework.py
@@ -17,6 +17,21 @@ def main():
     print("Starting...\n")
     url = input("Enter the url of the PDF:")
 
+    # Check that the URL provided by the user points to the entire document
+    # and not to a specific page (e.g. https://issuu.com/user/docs/doc
+    # instead of https://issuu.com/user/docs/doc/18)
+    url_end = re.search(r'(.+)/\d+/?$', url)
+    if url_end:
+        # If there is a page number at the end of the URL
+        print('The URL provided points to a specific page in the document.')
+        url_without_page_number = url_end.group(1)
+        print('Using the following URL instead:')
+        print(url_without_page_number)
+        url = url_without_page_number
+    else:
+        # If the URL points to the entire document, without any page number
+        pass
+
     url_open1 = str(urllib.request.urlopen(url).read().decode("utf-8"))
 
     # Credits to https://txt2re.com/ for the regex (Almost all of it)

--- a/framework.py
+++ b/framework.py
@@ -1,6 +1,5 @@
 import re
 import urllib
-import core.downloader as program
 
 # ----------
 # CONSTANTS
@@ -11,21 +10,29 @@ WIDTH_PDF = 1100
 HEIGHT_PDF = 900
 NAME_PDF = 'output.pdf'
 
-print("Starting...\n")
-url = input("Enter the url of the PDF:")
 
-url_open1 = str(urllib.request.urlopen(url).read().decode("utf-8"))
+def main():
+    import core.downloader as program
 
-# Credits to https://txt2re.com/ for the regex (Almost all of it)
-# Sorry, I'm not lazy, but I hate making regex's
-re1 = '.*?'
-re2 = '((?:http|https)(?::\\/{2}[\\w]+)(?:[\\/|\\.]?)(?:[^\\s"]*)(?:png|jpg))'
+    print("Starting...\n")
+    url = input("Enter the url of the PDF:")
 
-rg = re.compile(re1+re2, re.IGNORECASE | re.DOTALL)
-m = rg.search(url_open1)
-if m:
-    httpurl = m.group(1)
-    print('Starting from URI: ' + httpurl)
-    program.downloader(httpurl)
-else:
-    print("Error! No image was found")
+    url_open1 = str(urllib.request.urlopen(url).read().decode("utf-8"))
+
+    # Credits to https://txt2re.com/ for the regex (Almost all of it)
+    # Sorry, I'm not lazy, but I hate making regex's
+    re1 = '.*?'
+    re2 = '((?:http|https)(?::\\/{2}[\\w]+)(?:[\\/|\\.]?)(?:[^\\s"]*)(?:png|jpg))'
+
+    rg = re.compile(re1+re2, re.IGNORECASE | re.DOTALL)
+    m = rg.search(url_open1)
+    if m:
+        httpurl = m.group(1)
+        print('Starting from URI: ' + httpurl)
+        program.downloader(httpurl)
+    else:
+        print("Error! No image was found")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
If the URL provided by the user ends with the page number of the
Issuu document (e.g. https://issuu.com/user/docs/doc/18) then
the script would complete successfully but no image would be
downloaded and the pdf would be empty as a result.

This commit fixes the issue so that...
https://issuu.com/user/docs/doc/18/
is converted to...
https://issuu.com/user/docs/doc
before proceeding with the download.